### PR TITLE
A sensible error when graphviz-devel is missing

### DIFF
--- a/Libyui-qt-graphLibgvc.cmake
+++ b/Libyui-qt-graphLibgvc.cmake
@@ -1,8 +1,14 @@
 # find the correct libraries depending on libgvc's version
 
 MACRO( SET_LIBGVS_LIBS )
-	EXEC_PROGRAM(/usr/bin/pkg-config ARGS \"libgvc\" \"--libs\" OUTPUT_VARIABLE _tmp)
-	STRING(REPLACE " \n" "" _tmp "${_tmp}")
+	EXECUTE_PROCESS(COMMAND /usr/bin/pkg-config --libs libgvc
+	  RESULT_VARIABLE _exit
+	  OUTPUT_VARIABLE _tmp
+	  OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+	IF(${_exit} GREATER 0)
+	  MESSAGE(FATAL_ERROR "Install graphviz-devel")
+	ENDIF()
 	STRING(REPLACE "-l" "" _tmp "${_tmp}")
 	SEPARATE_ARGUMENTS(_tmp)
 	SET( LIB_LINKER ${_tmp} )


### PR DESCRIPTION
Before:

-- Found Libyui-qt:  (Version: 2.49.16)
CMake Error at /usr/share/libyui/buildtools/LibyuiCommon.cmake:306 (MESSAGE):
  Linker-Library Package NOT FOUND

After:

Package libgvc was not found in the pkg-config search path.
Perhaps you should add the directory containing `libgvc.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libgvc' found
CMake Error at Libyui-qt-graphLibgvc.cmake:10 (MESSAGE):
  Install graphviz-devel