### PR TITLE
Use new libyui SO version 12

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,9 +1,9 @@
 SET(VERSION_MAJOR "2")
 SET(VERSION_MINOR "46")
-SET(VERSION_PATCH "3")
+SET(VERSION_PATCH "4")
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
 
-##### This is need for the libyui core, ONLY.
+##### This is need for the libyui core ONLY.
 ##### These will be overridden from exports in LibyuiConfig.cmake
 SET( SONAME_MAJOR "0" )
 SET( SONAME_MINOR "0" )

--- a/package/libyui-qt-graph-doc.spec
+++ b/package/libyui-qt-graph-doc.spec
@@ -17,10 +17,10 @@
 
 
 %define parent libyui-qt-graph
-%define so_version 11
+%define so_version 12
 
 Name:           %{parent}-doc
-Version:        2.46.3
+Version:        2.46.4
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 

--- a/package/libyui-qt-graph.changes
+++ b/package/libyui-qt-graph.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun  4 12:46:44 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Use new parent lib SO version libyui.so.12 (bsc#1172513)
+- 2.46.4
+
+-------------------------------------------------------------------
 Tue May 19 10:49:53 CEST 2020 - aschnell@suse.com
 
 - allow to move graph by dragging mouse (bsc#1171865)

--- a/package/libyui-qt-graph.spec
+++ b/package/libyui-qt-graph.spec
@@ -17,11 +17,11 @@
 
 
 Name:           libyui-qt-graph
-Version:        2.46.3
+Version:        2.46.4
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 11
+%define so_version 12
 %define bin_name %{name}%{so_version}
 
 BuildRequires:  cmake >= 2.8


### PR DESCRIPTION
This is related to https://github.com/libyui/libyui/pull/165 :

The latest libyui needed to bump the SO version to 12 to maintain binary compatibility. The dependent packages like this need to adapt to that new version.
